### PR TITLE
[WIP] Add collectd types.db if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ influxdb_graphite_ignore_unnamed: "false"
 influxdb_collectd_enabled: "false"
 influxdb_collectd_bind_address: ""
 influxdb_collectd_database: ""
-influxdb_collectd_typesdb: ""
+influxdb_collectd_typesdb_directory: ""
 influxdb_collectd_batch_size: 1000
 influxdb_collectd_batch_pending: 5
 influxdb_collectd_batch_timeout: "1s"

--- a/tasks/collectd.yml
+++ b/tasks/collectd.yml
@@ -1,0 +1,21 @@
+- name: Create collectd typesdb if needed
+  file:
+    path: "{{ influxdb_collectd_typesdb_directory }}"
+    state: directory
+  tags:
+    - influxdb
+
+- name: Check collectd types.db existence
+  stat:
+    path: "{{ influxdb_collectd_typesdb_directory }}/types.db"
+  register: influxdb_collectd_typesdb
+  tags:
+    - influxdb
+
+- name: Get collectd types.db from github
+  get_url:
+    url: https://raw.githubusercontent.com/collectd/collectd/master/src/types.db
+    dest: "{{ influxdb_collectd_typesdb_directory }}/types.db"
+  when: not influxdb_collectd_typesdb.stat.exists
+  tags:
+    - influxdb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,6 +104,9 @@
   when: influxdb_merged_config | changed
   tags:
     - influxdb
+- name: Perform collectd specific configuration
+  include: collectd.yml
+  when: influxdb_collectd_enabled == 'true'
 
 - name: Ensure directories have correct permissions
   file:

--- a/templates/conf.j2
+++ b/templates/conf.j2
@@ -250,7 +250,7 @@ reporting-disabled = {{influxdb_reporting_disabled}}
   {% if influxdb_collectd_enabled == "true" %}
   bind-address = "{{influxdb_collectd_bind_address}}"
   database = "{{influxdb_collectd_database}}"
-  typesdb = "{{influxdb_collectd_typesdb}}"
+  typesdb = "{{influxdb_collectd_typesdb_directory}}/types.db"
 
   # These next lines control how batching works. You should have this enabled
   # otherwise you could get dropped metrics or poor performance. Batching

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -106,7 +106,7 @@ influxdb_graphite_ignore_unnamed: "false"
 influxdb_collectd_enabled: "false"
 influxdb_collectd_bind_address: ":25826"
 influxdb_collectd_database: "collectd"
-influxdb_collectd_typesdb: "/usr/share/collectd/types.db"
+influxdb_collectd_typesdb_directory: "/usr/share/collectd"
 influxdb_collectd_batch_size: 1000
 influxdb_collectd_batch_pending: 5
 influxdb_collectd_batch_timeout: "1s"


### PR DESCRIPTION
This PR fix an issue when collectd plugin is enabled : the absence of types.db file.

I made the choice to hardcode the types.db file name, letting the user to only chose the directory for the file. I wanted to have your opinion on this before introducing another variable for the filename.

Moreover, for now the types.db file is downloaded directly from github, do you agree with this ?

For testing, do you want to create a test folder with specific variables file for collectd and other plugins in the future ?
