### PR TITLE
Added default dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,3 +25,6 @@ galaxy_info:
     - database
     - database:nosql
     - monitoring
+
+dependencies: []
+


### PR DESCRIPTION
When installing with ansible-galaxy, it will print an error message:

```
- influxdb was installed successfully
Traceback (most recent call last):
  File "/usr/local/bin/ansible-galaxy", line 959, in <module>
    main()
  File "/usr/local/bin/ansible-galaxy", line 953, in main
    fn(args, options, parser)
  File "/usr/local/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'
```

Can be solved by adding the following to "meta":

```
dependencies: []
```
