### PR TITLE
Migrate from busser-ansible-spec

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,9 +7,7 @@ platforms:
   - name: "ubuntu-14.04"
 
 verifier:
-  name: busser
-  plugin:
-    - Ansiblespec
+  name: serverspec
 
 suites:
   - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 group :test do
   gem 'kitchen-ansible'
   gem 'kitchen-docker'
+  gem 'kitchen-verifier-serverspec'
   gem 'test-kitchen'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chef-config (12.7.2)
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     highline (1.7.8)
-    kitchen-ansible (0.0.37)
+    kitchen-ansible (0.0.38)
       librarian-ansible
       test-kitchen (~> 1.4)
     kitchen-docker (2.3.0)
       test-kitchen (>= 1.0.0)
+    kitchen-verifier-serverspec (0.3.0)
+      net-ssh (~> 2.0)
+      test-kitchen (~> 1.4)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-ansible (2.0.0)
+    librarian-ansible (3.0.0)
       faraday
       librarian (~> 0.1.0)
-    mixlib-config (2.2.1)
     mixlib-install (0.7.1)
     mixlib-shellout (2.2.6)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
+    net-ssh (2.9.4)
     safe_yaml (1.0.4)
-    test-kitchen (1.5.0)
-      chef-config (>= 12.5.1)
+    test-kitchen (1.6.0)
       mixlib-install (~> 0.7)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -42,7 +40,8 @@ PLATFORMS
 DEPENDENCIES
   kitchen-ansible
   kitchen-docker
+  kitchen-verifier-serverspec
   test-kitchen
 
 BUNDLED WITH
-   1.11.1
+   1.11.2


### PR DESCRIPTION
First attempt at migrating from busser-ansible-spec. This might be entirely incorrect...
