### PR TITLE
Use the shell verifier to run serverspec

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,7 +7,8 @@ platforms:
   - name: "ubuntu-14.04"
 
 verifier:
-  name: serverspec
+  name: shell
+  command: rspec -c -f d -I serverspec spec/*_spec.rb
 
 suites:
   - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 group :test do
   gem 'kitchen-ansible'
   gem 'kitchen-docker'
-  gem 'kitchen-verifier-serverspec'
   gem 'test-kitchen'
+  gem 'serverspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     artifactory (2.3.2)
+    diff-lcs (1.2.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     highline (1.7.8)
@@ -10,9 +11,6 @@ GEM
       test-kitchen (~> 1.4)
     kitchen-docker (2.3.0)
       test-kitchen (>= 1.0.0)
-    kitchen-verifier-serverspec (0.4.0)
-      net-ssh (~> 2.0)
-      test-kitchen (~> 1.4)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -25,11 +23,36 @@ GEM
       mixlib-versioning (>= 1.1.0)
     mixlib-shellout (2.2.6)
     mixlib-versioning (1.1.0)
+    multi_json (1.11.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.4)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
     safe_yaml (1.0.4)
+    serverspec (2.18.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.35)
+    specinfra (2.36.6)
+      net-scp
+      net-ssh
     test-kitchen (1.7.1)
       mixlib-install (~> 1.0, >= 1.0.2)
       mixlib-shellout (>= 1.2, < 3.0)
@@ -45,8 +68,8 @@ PLATFORMS
 DEPENDENCIES
   kitchen-ansible
   kitchen-docker
-  kitchen-verifier-serverspec
+  serverspec
   test-kitchen
 
 BUNDLED WITH
-   1.11.2
+   1.12.0

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,5 +1,8 @@
 require_relative './spec_helper.rb'
 
+# Wait for the converge to be complete before verification
+sleep(3)
+
 describe 'ubuntu', if: %w[debian ubuntu].include?(os[:family]) do
   describe group('influxdb') do
     it { should exist }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,5 @@ options[:keys]      = ENV['KITCHEN_SSH_KEY']
 
 set :host,        options[:host_name]
 set :ssh_options, options
-set :env, :LANG => 'C', :LC_ALL => 'C'
+set :env, LANG: 'C', LC_ALL: 'C'
 set :request_pty, true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,14 @@
-require 'rubygems'
-require 'bundler/setup'
-
 require 'serverspec'
-require 'pathname'
-require 'net/ssh'
 
-RSpec.configure do
-  set :host, ENV['TARGET_HOST']
-  set :request_pty, true
-end
+set :backend, :ssh
+
+options = Net::SSH::Config.for(host)
+options[:host_name] = ENV['KITCHEN_HOSTNAME']
+options[:user]      = ENV['KITCHEN_USERNAME']
+options[:port]      = ENV['KITCHEN_PORT']
+options[:keys]      = ENV['KITCHEN_SSH_KEY']
+
+set :host,        options[:host_name]
+set :ssh_options, options
+set :env, :LANG => 'C', :LC_ALL => 'C'
+set :request_pty, true


### PR DESCRIPTION
## Changes

Switch from kitchen-verifier-serverspec to the shell verifier that is now included in test-kitchen.
## Verify

The same specs as before are running correctly: `bundle exec kitchen test`

---

It is now the recommended way to run serverspec instead of using busser. Also it doesn't depend on the version of Ruby that can be installed on tested host, which can be a problem when testing older distributions that don't have a recent Ruby version in their package manager.
