### PR TITLE
Add support for influxdata repositories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,11 @@ influxdb_checksums:
 influxdb_arch: "amd64"
 influxdb_dl_url: "https://s3.amazonaws.com/influxdb/influxdb_{{  influxdb_ver  }}_{{  influxdb_arch  }}.deb"
 influxdb_pkg: "/usr/local/src/influxdb_{{  influxdb_ver  }}_{{  influxdb_arch  }}.deb"
+
+# Set influxdb_install_method to "repository" to install influxdb from influxdata's repository
+influxdb_install_method: "download"
+influxdb_repository_channel: "stable"
+
 influxdb_maxprocs: "{{ ansible_processor_vcpus }}"
 influxdb_hostname: "{{ ansible_default_ipv4.address }}"
 influxdb_keep_initd: false

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,0 +1,24 @@
+- name: Install any necessary dependency
+  apt:
+    name: "apt-transport-https"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Import InfluxData GPG signing key
+  apt_key:
+    url: https://repos.influxdata.com/influxdb.key
+    state: present
+    id: "0x2582E0C5"
+
+- name: Add InfluxData repository
+  apt_repository:
+    repo: deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ influxdb_repository_channel }}
+    state: present
+
+- name: Install InfluxDB package
+  apt:
+    name: influxdb
+    state: latest
+    update_cache: yes
+    cache_valid_time: 3600

--- a/tasks/install-download.yml
+++ b/tasks/install-download.yml
@@ -1,0 +1,15 @@
+# TODO: Use md5sum to check download
+- name: Download version
+  get_url:
+    url: "{{ influxdb_dl_url }}"
+    dest: "{{ influxdb_pkg }}"
+  tags:
+    - influxdb
+
+- name: Install package
+  command: "dpkg --skip-same-version -i {{ influxdb_pkg }}"
+  register: dpkg_result
+  changed_when: "dpkg_result.stdout.startswith('Selecting')"
+  when: ansible_distribution in ['Ubuntu', 'Debian']
+  tags:
+    - influxdb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,19 +19,13 @@
   include: collectd.yml
   when: influxdb_collectd_enabled == "true"
 
-# TODO: Use md5sum to check download
-- name: Download version
-  get_url:
-    url: "{{ influxdb_dl_url }}"
-    dest: "{{ influxdb_pkg }}"
+- include: install-download.yml
+  when: influxdb_install_method == "download"
   tags:
     - influxdb
 
-- name: Install package
-  command: "dpkg --skip-same-version -i {{ influxdb_pkg }}"
-  register: dpkg_result
-  changed_when: "dpkg_result.stdout.startswith('Selecting')"
-  when: ansible_distribution in ['Ubuntu', 'Debian']
+- include: install-debian.yml
+  when: influxdb_install_method == "repository" and ansible_distribution in ["Debian", "Ubuntu"]
   tags:
     - influxdb
 


### PR DESCRIPTION
## Changes

This change adds 2 variables:
### `influxdb_install_method`

When set to `download`, the current method of installing influxdb is used. When set to `repository`, the repository by influxdata (https://repos.influxdata.com/) are used.
### `influxdb_repository_channel`

When the `influxdb_install_method` is set to `repository`, this is the channel that used. By default, this is `stable`. But the repository offers `unstable` and `nightly` as well.
## Verify

Set `influxdb_install_method` to `repository` and run a playbook.
