### PR TITLE
Don't ask for user input when config files are updated in package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     - influxdb
 
 - name: Install package
-  command: "dpkg --skip-same-version -i {{ influxdb_pkg }}"
+  command: "dpkg --force-confdef --force-confold --skip-same-version -i {{ influxdb_pkg }}"
   register: dpkg_result
   changed_when: "dpkg_result.stdout.startswith('Selecting')"
   when: ansible_distribution in ['Ubuntu', 'Debian']


### PR DESCRIPTION
## Changes

Add '--force-conf-def' and '--force-confold' parameters to dpkg command so that it does not wait for user input when package contain updated configuration files.
## Verify

Do update from version 0.9 to the 0.11.1. Without those two additional flags ansible will bailout, because dpkg waits for the user input. With both flags it upgrades influxdb smoothly.

---

Add any relevant `fixes` or `closes` to reference github issues

Force dpkg to choose default or old configuration files when they are updated in the package. With both options ansible will not bailout during influxdb update.
