### PR TITLE
Changed 'include' to 'include_tasks'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,15 +16,15 @@
     - influxdb
 
 - name: Configure collectd
-  include: collectd.yml
+  include_tasks: collectd.yml
   when: influxdb_collectd_enabled == "true"
 
-- include: install-download.yml
+- include_tasks: install-download.yml
   when: influxdb_install_method == "download"
   tags:
     - influxdb
 
-- include: install-debian.yml
+- include_tasks: install-debian.yml
   when: influxdb_install_method == "repository" and ansible_distribution in ["Debian", "Ubuntu"]
   tags:
     - influxdb


### PR DESCRIPTION
Changed 'include' to 'include_tasks' as 'include' will be deprecated in ansible v2.8

## Changes

Outline changes pull request is introducing

## Verify

Add any steps on how to verify the changes work as intended

---

Add any relevant `fixes` or `closes` to reference github issues
