### PR TITLE
Make it possible to download/install Debian packages from a local mir…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ influxdb_pkg: "/usr/local/src/influxdb_{{  influxdb_ver  }}_{{  influxdb_arch  }
 influxdb_install_method: "repository" # or "download"
 influxdb_repository_channel: "stable"
 
+# Influx repo URLs
+influxdb_apt_repo_url: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ influxdb_repository_channel }}"
+influxdb_apt_key_url: "https://repos.influxdata.com/influxdb.key"
+
 influxdb_maxprocs: "{{ ansible_processor_vcpus }}"
 influxdb_hostname: "{{ ansible_nodename }}"
 influxdb_keep_initd: false

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -7,13 +7,13 @@
 
 - name: Import InfluxData GPG signing key
   apt_key:
-    url: https://repos.influxdata.com/influxdb.key
+    url: "{{ influxdb_apt_key_url }}"
     state: present
     id: "0x2582E0C5"
 
 - name: Add InfluxData repository
   apt_repository:
-    repo: deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ influxdb_repository_channel }}
+    repo: "{{ influxdb_apt_repo_url }}"
     state: present
 
 - name: Install InfluxDB package


### PR DESCRIPTION
…ror.

This is quite useful in cases where the destination node does not have
Internet egress access.

## Changes

This change provides variables for overriding the URLs to the Debian apt repo and its key, so that they can be pointed at local mirrors when needed.

## Verify

Add any steps on how to verify the changes work as intended

---

Add any relevant `fixes` or `closes` to reference github issues
