### PR TITLE
Fix templating error on ansible 2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.3
 before_install:
   - sudo apt-get update -qq
+  - sudo apt-get install python3
   - "curl -fsSL https://get.docker.com/ | sh"
   - sudo usermod -aG docker travis
 install:

--- a/role.yml
+++ b/role.yml
@@ -2,7 +2,7 @@
 
 - name: Test influxdb
   hosts: all
-  sudo: yes
+  become: true
   roles:
     - ""
   vars_files:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
   command: "{{ influxdb_influxd_bin }} config -config {{ influxdb_generated_config }}"
   register: influxdb_merged_config
   become: yes
-  when: write_config | changed
+  when: write_config.changed
   tags:
     - influxdb
 
@@ -69,7 +69,7 @@
     dest: "{{ influxdb_config_file }}"
     group: "{{ influxdb_group }}"
     owner: "{{ influxdb_user }}"
-  when: influxdb_merged_config | changed
+  when: influxdb_merged_config.changed
   tags:
     - influxdb
 


### PR DESCRIPTION
## Changes

This fixes:
```
TASK [mtchavez.influxdb : Run config update] *************************************************************
fatal: [gcc-8.training.galaxyproject.eu]: FAILED! => {"msg": "The conditional check 'write_config | changed' failed. The error was: template error while templating string: no filter named 'changed'. String: {% if write_config | changed %} True {% else %} False {% endif %}\n\nThe error appears to be in '/home/ubuntu/galaxy/roles/mtchavez.influxdb/tasks/main.yml': line 58, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Run config update\n  ^ here\n"
```



## Verify

Run the role on ansible >= 2.9.0

---

Add any relevant `fixes` or `closes` to reference github issues