### PR TITLE
Solving error: "No filter named 'changed'"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
   command: "{{ influxdb_influxd_bin }} config -config {{ influxdb_generated_config }}"
   register: influxdb_merged_config
   become: yes
-  when: write_config | changed
+  when: write_config is changed
   tags:
     - influxdb
 
@@ -69,7 +69,7 @@
     dest: "{{ influxdb_config_file }}"
     group: "{{ influxdb_group }}"
     owner: "{{ influxdb_user }}"
-  when: influxdb_merged_config | changed
+  when: influxdb_merged_config is changed
   tags:
     - influxdb
 


### PR DESCRIPTION
In ansible 2.10.4 when using v6.0.0 gives the error: `The error was: template error while templating string: no filter named 'changed'`
This is because "|" is deprecated. The solution is to replace "|" by "is"

## Changes

Change "|" to "is" in main.yml file

## Verify

Running the play-book installs influx-db successfully.


